### PR TITLE
Require user confirmation of awareness

### DIFF
--- a/test/counshell-test.el
+++ b/test/counshell-test.el
@@ -204,9 +204,15 @@
 
 ;; Test other
 
-(ert-deftest counshell-sh-read ()
+(ert-deftest counshell--sh-read-impl-test ()
   (with-mock
    (stub ivy-read => nil)
    (stub make-temp-file => "")
-   (should (equal (counshell-sh-read t "" "") nil))))
+   (should (equal (counshell--sh-read-impl t "" "") nil))))
 
+(ert-deftest counshell--sh-read-test ()
+  (with-mock
+   (stub yes-or-no-p => t)
+   (stub customize-save-variable => t)
+   (mock (counshell--sh-read-impl t "" "") => nil)
+   (should (equal (counshell-sh-read t "" "") nil))))


### PR DESCRIPTION
When the user invokes any counshell command for the first time, we ask
him to confirm that he is aware of the shell behavior. This is
intended to scare him a little bit, and to avoid misunderstandings. If
he answers yes, store that in a customizable variable.